### PR TITLE
Add optional $make_dir param.

### DIFF
--- a/src/wp-includes/fonts.php
+++ b/src/wp-includes/fonts.php
@@ -116,7 +116,7 @@ function wp_get_font_dir( $create_dir = false ) {
 
 	$is_writable = true;
 	if ( defined( 'WP_RUN_CORE_TESTS' ) ) {
-		// Allow mocking of unwritable wp-contwent directory
+		// Allow mocking of unwritable wp-content directory. chmod( WP_CONTENT_DIR, ... ) doesn't seem to work as expected.
 		$is_writable = apply_filters( 'font_dir__wp_content_is_writable', true );
 	}
 

--- a/src/wp-includes/fonts.php
+++ b/src/wp-includes/fonts.php
@@ -96,7 +96,7 @@ function wp_unregister_font_collection( string $slug ) {
  *
  * @since 6.5.0
  *
- * @param string|false $make_dir Pass `make` to attempt to make the directory if it does not exist.
+ * @param string|false $create_dir Pass `create` to attempt to make the directory if it does not exist.
  * @return array $defaults {
  *     Array of information about the upload directory.
  *
@@ -108,7 +108,7 @@ function wp_unregister_font_collection( string $slug ) {
  *     @type string|false $error   False or error message.
  * }
  */
-function wp_get_font_dir( $make_dir = false ) {
+function wp_get_font_dir( $create_dir = false ) {
 	$site_path = '';
 	if ( is_multisite() && ! ( is_main_network() && is_main_site() ) ) {
 		$site_path = '/sites/' . get_current_blog_id();
@@ -144,7 +144,7 @@ function wp_get_font_dir( $make_dir = false ) {
 	 */
 	$font_dir = apply_filters( 'font_dir', $default_dir );
 
-	if ( 'make' === $make_dir && ! is_dir( $font_dir['path'] ) ) {
+	if ( 'create' === $create_dir && ! is_dir( $font_dir['path'] ) ) {
 		// Attempt to create the directory.
 		wp_mkdir_p( $font_dir['path'] );
 	}

--- a/src/wp-includes/fonts.php
+++ b/src/wp-includes/fonts.php
@@ -114,8 +114,14 @@ function wp_get_font_dir( $create_dir = false ) {
 		$site_path = '/sites/' . get_current_blog_id();
 	}
 
+	$is_writable = true;
+	if ( defined( 'WP_RUN_CORE_TESTS' ) ) {
+		// Allow mocking of unwritable wp-contwent directory
+		$is_writable = apply_filters( 'font_dir__wp_content_is_writable', true );
+	}
+
 	// wp-content/fonts is the default location
-	if ( is_multisite() || ( is_dir( WP_CONTENT_DIR ) && wp_is_writable( WP_CONTENT_DIR ) ) ) {
+	if ( $is_writable && ( is_multisite() || ( is_dir( WP_CONTENT_DIR ) && wp_is_writable( WP_CONTENT_DIR ) ) ) ) {
 		$font_dir_path = path_join( WP_CONTENT_DIR, 'fonts' ) . $site_path;
 		$font_dir_url  = untrailingslashit( content_url( 'fonts' ) ) . $site_path;
 	} else {

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-font-faces-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-font-faces-controller.php
@@ -866,7 +866,7 @@ class WP_REST_Font_Faces_Controller extends WP_REST_Posts_Controller {
 		 * To avoid an infinite loop, don't hook wp_get_font_dir() to 'upload_dir'.
 		 * Instead, just pass its return value to the 'upload_dir' callback.
 		 */
-		$font_dir       = wp_get_font_dir();
+		$font_dir       = wp_get_font_dir( 'create' );
 		$set_upload_dir = function () use ( $font_dir ) {
 			return $font_dir;
 		};

--- a/tests/phpunit/tests/fonts/font-library/fontLibraryHooks.php
+++ b/tests/phpunit/tests/fonts/font-library/fontLibraryHooks.php
@@ -72,14 +72,18 @@ class Tests_Fonts_FontLibraryHooks extends WP_UnitTestCase {
 	protected function upload_font_file( $font_filename ) {
 		$font_file_path = DIR_TESTDATA . '/fonts/' . $font_filename;
 
+		$upload_dir_override = function() {
+			return wp_get_font_dir( 'create' );
+		};
+
 		add_filter( 'upload_mimes', array( 'WP_Font_Utils', 'get_allowed_font_mime_types' ) );
-		add_filter( 'upload_dir', 'wp_get_font_dir' );
+		add_filter( 'upload_dir', $upload_dir_override );
 		$font_file = wp_upload_bits(
 			$font_filename,
 			null,
 			file_get_contents( $font_file_path )
 		);
-		remove_filter( 'upload_dir', 'wp_get_font_dir' );
+		remove_filter( 'upload_dir', $upload_dir_override );
 		remove_filter( 'upload_mimes', array( 'WP_Font_Utils', 'get_allowed_font_mime_types' ) );
 
 		return $font_file;

--- a/tests/phpunit/tests/fonts/font-library/fontLibraryHooks.php
+++ b/tests/phpunit/tests/fonts/font-library/fontLibraryHooks.php
@@ -72,7 +72,7 @@ class Tests_Fonts_FontLibraryHooks extends WP_UnitTestCase {
 	protected function upload_font_file( $font_filename ) {
 		$font_file_path = DIR_TESTDATA . '/fonts/' . $font_filename;
 
-		$upload_dir_override = function() {
+		$upload_dir_override = function () {
 			return wp_get_font_dir( 'create' );
 		};
 

--- a/tests/phpunit/tests/fonts/font-library/wpFontsDir.php
+++ b/tests/phpunit/tests/fonts/font-library/wpFontsDir.php
@@ -120,7 +120,6 @@ class Tests_Fonts_WpFontDir extends WP_UnitTestCase {
 			'error'   => false,
 		);
 
-
 		add_filter( 'font_dir__wp_content_is_writable', '__return_false' );
 		$font_dir = wp_get_font_dir( 'create' );
 		remove_filter( 'font_dir__wp_content_is_writable', '__return_false' );

--- a/tests/phpunit/tests/fonts/font-library/wpFontsDir.php
+++ b/tests/phpunit/tests/fonts/font-library/wpFontsDir.php
@@ -55,7 +55,7 @@ class Tests_Fonts_WpFontDir extends WP_UnitTestCase {
 		add_filter( 'font_dir', 'set_new_values' );
 
 		// Gets the fonts dir.
-		$font_dir = wp_get_font_dir();
+		$font_dir = wp_get_font_dir( 'create' );
 
 		$expected = array(
 			'path'    => path_join( WP_CONTENT_DIR, 'custom_dir' ),
@@ -72,7 +72,7 @@ class Tests_Fonts_WpFontDir extends WP_UnitTestCase {
 		$this->assertSame( $expected, $font_dir, 'The wp_get_font_dir() method should return the expected values.' );
 
 		// Gets the fonts dir.
-		$font_dir = wp_get_font_dir();
+		$font_dir = wp_get_font_dir( 'create' );
 
 		$this->assertSame( static::$dir_defaults, $font_dir, 'The wp_get_font_dir() method should return the default values.' );
 	}
@@ -120,10 +120,10 @@ class Tests_Fonts_WpFontDir extends WP_UnitTestCase {
 			'error'   => false,
 		);
 
-		$this->create_fake_file_to_avoid_dir_creation( static::$dir_defaults['path'] );
-		$this->assertFileExists( static::$dir_defaults['path'] );
 
-		$font_dir = wp_get_font_dir();
+		add_filter( 'font_dir__wp_content_is_writable', '__return_false' );
+		$font_dir = wp_get_font_dir( 'create' );
+		remove_filter( 'font_dir__wp_content_is_writable', '__return_false' );
 
 		$this->assertDirectoryDoesNotExist( static::$dir_defaults['path'], 'The `wp-content/fonts` directory should not exist.' );
 		$this->assertDirectoryExists( $font_dir['path'], 'The `uploads/fonts` directory should exist.' );
@@ -131,10 +131,6 @@ class Tests_Fonts_WpFontDir extends WP_UnitTestCase {
 	}
 
 	public function test_should_return_error_if_unable_to_create_fonts_dir_in_uploads() {
-		// Disallow the creation of the `wp-content/fonts` directory.
-		$this->create_fake_file_to_avoid_dir_creation( static::$dir_defaults['path'] );
-		$this->assertFileExists( static::$dir_defaults['path'] );
-
 		// Disallow the creation of the `uploads/fonts` directory.
 		$upload_dir       = wp_upload_dir();
 		$font_upload_path = path_join( $upload_dir['basedir'], 'fonts' );
@@ -150,7 +146,9 @@ class Tests_Fonts_WpFontDir extends WP_UnitTestCase {
 			'error'   => 'Unable to create directory wp-content/uploads/fonts. Is its parent directory writable by the server?',
 		);
 
-		$font_dir = wp_get_font_dir();
+		add_filter( 'font_dir__wp_content_is_writable', '__return_false' );
+		$font_dir = wp_get_font_dir( 'create' );
+		remove_filter( 'font_dir__wp_content_is_writable', '__return_false' );
 
 		$this->assertDirectoryDoesNotExist( $font_upload_path, 'The `uploads/fonts` directory should not exist.' );
 		$this->assertSame( $expected, $font_dir, 'As /wp-content/uplods/fonts is not writable the error key should be populated with an error message.' );


### PR DESCRIPTION
This also depend only on `wp_is_writable( WP_CONTENT_DIR )` to change the location to /uploads/fonts, and doesn't try to create a dir. 

Also, current tests fail, would need fixing because of the new param, and because the workaround to create a file to prevent creation of the dir doesn't work now.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
